### PR TITLE
Add support to define before/after graphql-sequelize hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ readonly: false, // exclude create/delete/update mutations automatically
 fetchDeleted: false, // same as fetchDeleted as global except it lets you override global settings
 restoreDeleted: false // same as restoreDeleted as global except it lets you override global settings
 ```
+```javascript
+// define hooks to be invoked on find queries {before, after}
+find: {}
+```
 ### Usage in Model
 ```javascript
 Product.graphql = {

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,8 @@ const defaultModelGraphqlOptions = {
   joins: false, // make a query using join (left/right/inner) instead of batch dataloader, join will appear in all subtype args. Right join won't work for sqlite
   readonly: false, // exclude create/delete/update mutations automatically
   fetchDeleted: false, // same as fetchDeleted as global except it lets you override global settings
-  restoreDeleted: false // same as restoreDeleted as global except it lets you override global settings
+  restoreDeleted: false, // same as restoreDeleted as global except it lets you override global settings
+  find: {} // define graphql-sequelize find hooks {before, after}
 };
 
 const GenerateQueries = require('./libs/generateQueries');

--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -49,7 +49,7 @@ module.exports = (options) => {
     const before = (findOptions, args) => {
       // hook coming from graphql.find.before
       if (model.graphql.find?.before) {
-        model.graphql.beforeFind(findOptions, args, context);
+        model.graphql.find.before(findOptions, args, context);
       }
 
       if (isAssociation && model.through) {

--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -48,7 +48,7 @@ module.exports = (options) => {
     // sequelize-graphql before hook to parse orderby clause to make sure it supports multiple orderby
     const before = (findOptions, args) => {
       // hook coming from graphql.find.before
-      if (model.graphql.find?.before) {
+      if (model.graphql?.find?.before) {
         model.graphql.find.before(findOptions, args, context);
       }
 
@@ -78,7 +78,7 @@ module.exports = (options) => {
       return findOptions;
     };
 
-    const after = model.graphql.find?.after;
+    const after = model.graphql?.find?.after;
 
     // see if a scope is specified to be applied to find queries.
     const variablePath = { args, context };

--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -47,6 +47,10 @@ module.exports = (options) => {
 
     // sequelize-graphql before hook to parse orderby clause to make sure it supports multiple orderby
     const before = (findOptions, args) => {
+      // hook coming from graphql.find.before
+      if (model.graphql.find?.before) {
+        model.graphql.beforeFind(findOptions, args, context);
+      }
 
       if (isAssociation && model.through) {
         findOptions.through = {
@@ -74,12 +78,15 @@ module.exports = (options) => {
       return findOptions;
     };
 
+    const after = model.graphql.find?.after;
+
     // see if a scope is specified to be applied to find queries.
     const variablePath = { args, context };
     const scope = Array.isArray(graphql.scopes) ? { method: [graphql.scopes[0], _.get(variablePath, graphql.scopes[1], graphql.scopes[2] || null)] } : graphql.scopes;
     const resolverOptions = {
       before,
-      separate: isAssociation
+      after,
+      separate: isAssociation,
     };
 
     const data = await resolver((isAssociation ? model : model.scope(scope)), resolverOptions)(source, args, context, info);


### PR DESCRIPTION
Add support to define before/after `graphql-sequelize` before and after hooks on a model.
With this change, if you have added a `before` or `after` find hook then it will be invoked.

This allows you to define the hooks on the model graphql object like so:
```
 model.graphql = {
    find: {
        before: (findOptions, args, context) => {
            // modify findOptions
            console.log(findOptions);
        },
        after: (result, args, context) => {
           // do something with result
            console.log(result);
            return result;
        }
    }
}
```
The definition of `graphql-sequelize` hook options can be found at https://github.com/mickhansen/graphql-sequelize/tree/a8bccd7f09f8a89aca689104800083f4e17e8ab4#options

Please see #59 for more details.