### PR TITLE
fix: remove errors for joins option

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -133,7 +133,8 @@ const getIncludes = (ast, modelName, models) => {
         model: associations[key].target,
         required: join === 'INNER',
         right: join === 'RIGHT',
-        include: fieldsAst ? getIncludes(fieldsAst, key, models) : []
+        as: key,
+        include: fieldsAst ? getIncludes(fieldsAst, associations[key].target.name, models) : []
       });
 
       includes.push(include);


### PR DESCRIPTION
When used `model.graphql.joins = true ` option appears some errors:
```
  "errors": [
    {
      "message": "Cannot read property 'associations' of undefined",
```
AND
```
  "errors": [
    {
      "message": "FIELD is associated to TABLE using an alias. You must use the 'as' keyword to specify the alias within your include statement.",
```