### PR TITLE
Should permissions.conditions apply to associations?

### DIFF
--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -77,7 +77,7 @@ module.exports = (options) => {
       }
 
       if (!isAssociation && permissions?.conditions) {
-        
+
         const clauses = permissions.conditions.reduce((all, condition) => {
 
           if (typeof condition.value === 'string' && condition.value.startsWith(':')) {

--- a/src/resolvers/query.js
+++ b/src/resolvers/query.js
@@ -76,7 +76,7 @@ module.exports = (options) => {
         findOptions.include = includes;
       }
 
-      if (permissions && permissions.conditions) {
+      if (!isAssociation && permissions?.conditions) {
         
         const clauses = permissions.conditions.reduce((all, condition) => {
 


### PR DESCRIPTION
Given these rules:

```
{
  rules: {
    fetch: [
      {
        model: 'User',
        fields: [],
        associations: [],
        conditions: [
          { field: 'tenantId', value: ':ctx.state.user.tenantId' }
        ]
      },
      {
        model: 'Role',
        fields: [],
        associations: [],
        conditions: []
      },
    ]
  }
}
```

and this Graphql query:

```
query {
  UserCurrent { // custom query that returns the current user
    id
    name
    Roles {
      id
      name
    }
  }
}
```

when the Roles association is loaded, the generated SQL includes `where Role.tenantId = X`, which of course doesn't exist on that model.

It could be as simple as adding the `!isAssociation` check like in this PR, but should it be going a step further and looking for any conditions defined in `permissions.rules` for the associated model?

For example, if you had

```
{
  model: 'Role',
  fields: [],
  associations: [],
  conditions: [
    { field: 'active', value: true }
  ]
}
```

you'd probably want this condition to run as well.
